### PR TITLE
Fixes a reference error in class creation

### DIFF
--- a/Highrise.php
+++ b/Highrise.php
@@ -32,7 +32,8 @@ class Highrise {
 	function __construct($subdomain, $token){
 	
 		// subdomain
-		$subdomain = array_shift(explode('.', $subdomain));
+		$exploded = explode('.', $subdomain);
+		$subdomain = array_shift($exploded);
 		$this->apiUrl = str_replace('{sub}', $subdomain, $this->apiUrl);
 		
 		// token


### PR DESCRIPTION
`array_shift` requires a reference, and the returned array from `explode` isn't a reference.